### PR TITLE
test: increase unit test coverage to 99%

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,13 @@
 name: docs
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,21 +218,76 @@ jobs:
       - name: Run smoke test against TestPyPI package
         run: |
           python - <<'PY'
+          import numpy as np
           from sklearn.datasets import make_blobs
           from core_sg import CoreSG
 
-          X, _ = make_blobs(
-              n_samples=500,
+          def assert_hierarchy_outputs(core, X, *, k_max):
+              assert core.n_samples_ == X.shape[0]
+              assert core.k_max_ == k_max
+              assert core.labels_ is not None
+              assert core.labels_.shape == (X.shape[0],)
+              assert core.probabilities_ is not None
+              assert core.probabilities_.shape == (X.shape[0],)
+              assert core.cluster_persistence_ is not None
+              assert core.condensed_tree_.to_pandas().shape[0] >= X.shape[0]
+              assert core.single_linkage_tree_.to_pandas().shape[0] == X.shape[0] - 1
+              assert core.minimum_spanning_tree_.to_pandas().shape[0] == X.shape[0] - 1
+
+          X, _ = make_blobs(n_samples=120, n_features=3, centers=3, random_state=42)
+          connected_X, _ = make_blobs(
+              n_samples=80,
               n_features=3,
-              centers=3,
-              random_state=42,
+              centers=1,
+              cluster_std=0.75,
+              random_state=123,
           )
 
-          core = CoreSG(metric="euclidean", p=2)
-          core.fit(X, k_max=5)
-          mst = core.extract_mst_from_core_sg(k=3)
+          core_first = CoreSG(metric="euclidean", p=2, no_noise=False)
+          core_first.fit(X, k_max=6)
+          core_first.extract_hierarchy_from_core_sg(k=4)
+          assert_hierarchy_outputs(core_first, X, k_max=6)
 
-          assert mst is not None
+          core_second = CoreSG(
+              metric="manhattan",
+              p=2,
+              no_noise=False,
+              cluster_selection_method="leaf",
+              allow_single_cluster=True,
+          )
+          core_second.fit(X, k_max=5)
+          core_second.extract_hierarchy_from_core_sg(k=3)
+          assert_hierarchy_outputs(core_second, X, k_max=5)
+
+          score_first = CoreSG(
+              metric="euclidean",
+              p=2,
+              algorithm="score-sg",
+              random_state=42,
+              no_noise=False,
+          )
+          score_first.fit(connected_X, k_max=6)
+          score_first.extract_hierarchy_from_core_sg(k=4)
+          assert_hierarchy_outputs(score_first, connected_X, k_max=6)
+          assert score_first.anti_hubs_.shape == (
+              int(np.floor(np.sqrt(connected_X.shape[0]))),
+          )
+
+          score_second = CoreSG(
+              metric="euclidean",
+              p=2,
+              algorithm="score-sg",
+              random_state=7,
+              approx_knn_kwargs={"n_trees": 8},
+              no_noise=False,
+              cluster_selection_method="leaf",
+              allow_single_cluster=True,
+          )
+          score_second.fit(connected_X, k_max=5)
+          score_second.extract_hierarchy_from_core_sg(k=3)
+          assert_hierarchy_outputs(score_second, connected_X, k_max=5)
+          assert score_second.anti_hubs_.shape == score_first.anti_hubs_.shape
+
           print("Smoke test passed.")
           PY
 
@@ -295,20 +350,75 @@ jobs:
       - name: Run smoke test against PyPI package
         run: |
           python - <<'PY'
+          import numpy as np
           from sklearn.datasets import make_blobs
           from core_sg import CoreSG
 
-          X, _ = make_blobs(
-              n_samples=500,
+          def assert_hierarchy_outputs(core, X, *, k_max):
+              assert core.n_samples_ == X.shape[0]
+              assert core.k_max_ == k_max
+              assert core.labels_ is not None
+              assert core.labels_.shape == (X.shape[0],)
+              assert core.probabilities_ is not None
+              assert core.probabilities_.shape == (X.shape[0],)
+              assert core.cluster_persistence_ is not None
+              assert core.condensed_tree_.to_pandas().shape[0] >= X.shape[0]
+              assert core.single_linkage_tree_.to_pandas().shape[0] == X.shape[0] - 1
+              assert core.minimum_spanning_tree_.to_pandas().shape[0] == X.shape[0] - 1
+
+          X, _ = make_blobs(n_samples=120, n_features=3, centers=3, random_state=42)
+          connected_X, _ = make_blobs(
+              n_samples=80,
               n_features=3,
-              centers=3,
-              random_state=42,
+              centers=1,
+              cluster_std=0.75,
+              random_state=123,
           )
 
-          core = CoreSG(metric="euclidean", p=2)
-          core.fit(X, k_max=5)
-          mst = core.extract_mst_from_core_sg(k=3)
+          core_first = CoreSG(metric="euclidean", p=2, no_noise=False)
+          core_first.fit(X, k_max=6)
+          core_first.extract_hierarchy_from_core_sg(k=4)
+          assert_hierarchy_outputs(core_first, X, k_max=6)
 
-          assert mst is not None
+          core_second = CoreSG(
+              metric="manhattan",
+              p=2,
+              no_noise=False,
+              cluster_selection_method="leaf",
+              allow_single_cluster=True,
+          )
+          core_second.fit(X, k_max=5)
+          core_second.extract_hierarchy_from_core_sg(k=3)
+          assert_hierarchy_outputs(core_second, X, k_max=5)
+
+          score_first = CoreSG(
+              metric="euclidean",
+              p=2,
+              algorithm="score-sg",
+              random_state=42,
+              no_noise=False,
+          )
+          score_first.fit(connected_X, k_max=6)
+          score_first.extract_hierarchy_from_core_sg(k=4)
+          assert_hierarchy_outputs(score_first, connected_X, k_max=6)
+          assert score_first.anti_hubs_.shape == (
+              int(np.floor(np.sqrt(connected_X.shape[0]))),
+          )
+
+          score_second = CoreSG(
+              metric="euclidean",
+              p=2,
+              algorithm="score-sg",
+              random_state=7,
+              approx_knn_kwargs={"n_trees": 8},
+              no_noise=False,
+              cluster_selection_method="leaf",
+              allow_single_cluster=True,
+          )
+          score_second.fit(connected_X, k_max=5)
+          score_second.extract_hierarchy_from_core_sg(k=3)
+          assert_hierarchy_outputs(score_second, connected_X, k_max=5)
+          assert score_second.anti_hubs_.shape == score_first.anti_hubs_.shape
+
           print("Smoke test passed.")
           PY

--- a/doc/testing_guide.md
+++ b/doc/testing_guide.md
@@ -8,18 +8,24 @@ Its goal is to replace fragmented or inconsistent test notes with a single refer
 
 The current validation strategy for Core-SG is centered on the public behavior of the library:
 
+- exposing the scikit-learn-style `CoreSGClusterer` estimator lifecycle
 - building the Core-SG support from input data
 - extracting MSTs for a requested `k`
 - reconstructing HDBSCAN-style hierarchy artifacts
 - exposing cached objects from the reference fit at `k_max`
+- handling `algorithm="score-sg"` and disconnected support-graph failures
+- isolating private HDBSCAN API compatibility behind `hdbscan_adapter`
+- optionally reassigning noise labels without mutating unrelated artifacts
 - handling invalid parameters consistently
 
 Because the project is a graph- and MST-focused companion library for HDBSCAN-style workflows, the most important tests are the ones that confirm:
 
-1. the reusable Core-SG structures are built correctly
-2. extracted MSTs are structurally valid
-3. hierarchy artifacts are exposed consistently
-4. failure cases raise the expected errors instead of failing silently
+1. `CoreSGClusterer` builds the native `CoreSG` object once and reuses it
+2. the reusable Core-SG structures are built correctly
+3. extracted MSTs are structurally valid
+4. hierarchy artifacts are exposed consistently
+5. HDBSCAN-style parameters are forwarded only when supported
+6. failure cases raise the expected errors instead of failing silently
 
 ## 2. Dependencies used to run tests locally
 
@@ -38,6 +44,7 @@ The runtime dependencies used by the library are declared in `pyproject.toml` an
 - `pandas`
 - `scikit-learn`
 - `hdbscan`
+- `pynndescent`
 
 Python `>=3.10` is required by the package metadata.
 
@@ -62,7 +69,7 @@ Both approaches are consistent with the package metadata currently defined in `p
 Run the full test suite from the repository root with:
 
 ```bash
-pytest
+pytest tests -q
 ```
 
 To see coverage information:
@@ -76,6 +83,13 @@ To run the lint and formatting checks enforced by CI:
 ```bash
 ruff check core_sg tests
 ruff format --check core_sg tests
+```
+
+The release verification command includes benchmarking utilities as well:
+
+```bash
+ruff check core_sg tests benchmarking
+python -m ruff format --check .
 ```
 
 To validate the package build and metadata locally:
@@ -141,14 +155,36 @@ These tests verify that the package exposes the public API expected by users.
 What is tested:
 
 - `from core_sg import CoreSG` works
+- `from core_sg import CoreSGClusterer` works
 - the package exports `CoreSG` through `core_sg/__init__.py`
+- the package exports `CoreSGClusterer` through `core_sg/__init__.py`
 - the library can be imported after editable installation without path hacks
 
 Why it matters:
 
 This is the first user-facing contract of the package. If the public import fails, the package is effectively unusable.
 
-### 6.2 Core-SG build from raw data
+### 6.2 `CoreSGClusterer` lifecycle
+
+These tests validate the scikit-learn-style estimator wrapper.
+
+What is tested:
+
+- the first `fit(X, k=...)` creates one native `CoreSG` object
+- later `fit(X, k=...)` calls reuse the existing `core_sg_`
+- later fits extract only the requested hierarchy and do not rebuild support
+- `fit_predict(X, k=...)` returns the same labels exposed through `labels_`
+- `fit(X, k=None)` uses the fitted `k_max_`
+- `set_params(...)` after fitting changes constructor parameters without mutating learned attributes
+- `clone(fitted_clusterer)` returns an unfitted estimator
+- `get_fitted_core_sg()` returns the exact fitted native object and raises before fit
+- invalid first-fit inputs are rejected, while post-fit calls still validate `k`
+
+Why it matters:
+
+`CoreSGClusterer` is the recommended public API. Its reuse behavior is the user-facing expression of Core-SG's multi-`k` value proposition.
+
+### 6.3 Core-SG build from raw data
 
 These tests validate the behavior of `build_core_sg_from_data(...)` and the `fit(...)` path of `CoreSG`.
 
@@ -165,39 +201,47 @@ Why it matters:
 
 This is the foundation of the whole library. Every later extraction depends on the correctness of this initial build step.
 
-### 6.3 Validation of invalid parameters
+### 6.4 Validation of invalid parameters
 
 These tests confirm that invalid inputs raise explicit errors.
 
 What is tested:
 
 - `n <= 1` is rejected
-- `k_max <= 0` is rejected
+- `k_max <= 0` and `k_max == 1` are rejected
 - `k_max >= n` is rejected
 - `k_max < 2` is rejected for HDBSCAN-compatible flows
+- boolean and non-integer `k_max` values are rejected by the estimator
 - invalid `k` values passed to MST or hierarchy extraction are rejected
+- boolean and non-integer `k` values are rejected by the estimator
+- 1D, empty, one-sample, NaN, infinite, sparse, and precomputed estimator inputs are rejected on first fit
 
 Why it matters:
 
 The project should fail fast and clearly when the requested configuration is impossible or inconsistent.
 
-### 6.4 MST extraction from Core-SG
+### 6.5 MST extraction from Core-SG
 
 These tests validate `mst_from_core_sg(...)` and `CoreSG.extract_mst_from_core_sg(...)`.
 
 What is tested:
 
 - MST extraction returns exactly `n - 1` edges
+- MST arrays have shape `(n_samples - 1, 3)`
+- MST weights are finite
 - returned edges are sorted by weight
 - the MST is produced for `k <= k_max`
 - extraction at `k == k_max` reuses the cached fit artifact
+- extraction at `k < k_max` recomputes through reweighting and Kruskal
 - optional DataFrame conversion via `toDF=True` returns typed columns
+- invalid `k` values raise `ValueError`
+- disconnected `score-sg` support graphs raise an explicit error
 
 Why it matters:
 
 MST extraction is one of the central promises of the library. It must be correct, reproducible, and convenient to inspect.
 
-### 6.5 Mutual reachability reweighting behavior
+### 6.6 Mutual reachability reweighting behavior
 
 These tests validate the reweighted graph returned by `get_core_sg_mutual_reachability_distance(...)` and related helpers.
 
@@ -212,7 +256,7 @@ Why it matters:
 
 This is the mechanism that enables reuse across multiple values of `k`, which is the main technical value proposition of Core-SG.
 
-### 6.6 Hierarchy extraction and HDBSCAN-style outputs
+### 6.7 Hierarchy extraction and HDBSCAN-style outputs
 
 These tests validate `extract_hierarchy_from_core_sg(...)` and the tree-to-label conversion flow.
 
@@ -224,12 +268,15 @@ What is tested:
 - condensed tree, single linkage tree, and minimum spanning tree are populated
 - extracting at `k == k_max` reuses the cached fit-time artifacts
 - extracting at `k < k_max` builds the hierarchy from the extracted MST
+- current artifacts update when a new `k` is extracted
+- fit-time `k_max` artifacts remain unchanged after smaller-`k` extraction
+- `CoreSGClusterer` outputs match the equivalent native `CoreSG` workflow
 
 Why it matters:
 
 Users rely on Core-SG not only for MSTs but also for HDBSCAN-style downstream clustering artifacts.
 
-### 6.7 Wrapped object accessors
+### 6.8 Wrapped object accessors
 
 These tests validate the property accessors that expose HDBSCAN-compatible wrapper objects.
 
@@ -240,12 +287,14 @@ What is tested:
 - `minimum_spanning_tree_` raises an error before hierarchy extraction
 - fit-time accessors such as `condensed_tree_k_max_` raise an error before `fit`
 - wrapped objects are returned after the corresponding raw arrays are available
+- `to_pandas()` on single linkage and MST wrappers returns `n_samples - 1` rows
+- raw arrays remain available through `get_fitted_hdbscan_objects(wrapped=False)`
 
 Why it matters:
 
 The properties are part of the public interface and should fail predictably when called too early.
 
-### 6.8 Cached fitted-object retrieval
+### 6.9 Cached fitted-object retrieval
 
 These tests validate `get_fitted_hdbscan_objects(...)`.
 
@@ -260,7 +309,7 @@ Why it matters:
 
 This method is a core part of the reusable workflow and should be reliable for both interactive usage and downstream tooling.
 
-### 6.9 DataFrame conversion helper
+### 6.10 DataFrame conversion helper
 
 These tests validate `_mst_to_dataframe(...)`.
 
@@ -274,7 +323,7 @@ Why it matters:
 
 This is a small helper, but it affects usability in notebooks, reports, and diagnostics.
 
-### 6.10 Metric-specific behavior
+### 6.11 Metric-specific behavior
 
 These tests validate the metric branches inside `build_core_sg_from_data(...)`.
 
@@ -289,7 +338,7 @@ Why it matters:
 
 The graph structure depends directly on the pairwise distance computation, so metric-specific regressions can silently affect all downstream results.
 
-### 6.11 Precomputed-style and missing-raw-data behavior
+### 6.12 Precomputed-style and missing-raw-data behavior
 
 These tests validate behavior when raw feature data is unavailable for wrapped MST visualization.
 
@@ -298,7 +347,96 @@ What is tested:
 - MST wrapper access returns `None` with a warning when raw data is unavailable
 - raw arrays remain available even when the wrapped plotting object cannot be built
 
-### 6.12 Responsibility grouping and naming conventions
+Why it matters:
+
+This behavior is intentional in the current implementation and should be documented and tested so users understand the limitation.
+
+### 6.13 HDBSCAN adapter compatibility
+
+These tests validate the adapter layer that isolates HDBSCAN private API usage.
+
+What is tested:
+
+- `_tree_to_labels(...)` signatures with the current full parameter set
+- older `_tree_to_labels(...)` signatures missing optional parameters
+- signatures with no optional tree-selection keyword arguments
+- signatures that accept `**kwargs`
+- unsupported keyword arguments are filtered unless the target explicitly accepts `**kwargs`
+- the minimum spanning tree is appended to the returned tuple
+
+Why it matters:
+
+HDBSCAN's private function signatures can differ across releases. Core-SG should expose stable public parameters while adapting safely to the installed HDBSCAN version.
+
+### 6.14 HDBSCAN-style parameter forwarding
+
+These tests validate user-facing HDBSCAN-style parameters accepted by `CoreSG` and `CoreSGClusterer`.
+
+What is tested:
+
+- supported parameters are stored on the object
+- supported non-`None` values are considered for tree-to-label conversion
+- unsupported parameters are not forwarded
+- `None` values are not forwarded
+- adapter-side filtering handles installed-version signature differences
+
+Why it matters:
+
+This protects the public API from both accidental parameter loss and accidental forwarding of unsupported arguments.
+
+### 6.15 Noise handling pipeline
+
+These tests validate optional noise-label reassignment.
+
+What is tested:
+
+- `no_noise=False` preserves `-1` labels
+- `no_noise=True` reassigns `-1` labels when possible
+- only `labels_` is modified by noise reassignment
+- `probabilities_`, `cluster_persistence_`, and tree artifacts remain unchanged
+- invalid `c` values are rejected
+- `noise_label_strategy="mst_label_propagation"` is accepted
+- unknown noise strategies raise a clear error
+
+Why it matters:
+
+Noise handling is a post-processing step and should not silently mutate probability, persistence, or tree artifacts.
+
+### 6.16 `score-sg` behavior
+
+These tests validate the approximate anti-hub reinforced construction path.
+
+What is tested:
+
+- `algorithm="score-sg"` exposes `anti_hubs_`
+- `anti_hubs_` has stable shape and integer dtype
+- random tie-breaking is reproducible for a fixed `random_state`
+- `approx_knn_kwargs` is forwarded to PyNNDescent without in-place mutation
+- connected support graphs can complete fit and hierarchy extraction
+- disconnected support graphs raise errors containing `support graph is disconnected`
+- `CoreSGClusterer(algorithm="score-sg")` works and reuses `core_sg_` on repeated fits
+
+Why it matters:
+
+`score-sg` is the scalable approximate path. Its behavior has different dependencies and failure modes from the exact Core-SG path, so it needs focused coverage.
+
+### 6.17 Release smoke tests
+
+The release workflow contains post-publish smoke tests in `.github/workflows/release.yml`.
+
+What is tested:
+
+- after TestPyPI publication, the package is installed from TestPyPI and exercised
+- after PyPI publication, the package is installed from PyPI and exercised
+- the smoke script runs two `CoreSG` instances with different parameters
+- the smoke script runs two `CoreSG(algorithm="score-sg")` instances with different parameters
+- each run fits, extracts hierarchy artifacts, and validates labels, probabilities, persistence, tree wrappers, MST wrappers, and `score-sg` anti-hubs
+
+Why it matters:
+
+These checks validate the installed distribution immediately after deployment, not just the local working tree.
+
+### 6.18 Responsibility grouping and naming conventions
 
 The current suite also enforces organizational conventions intended to keep the repository maintainable over time.
 
@@ -312,10 +450,6 @@ What is expected:
 Why it matters:
 
 Good test structure reduces contributor confusion, makes future gaps easier to spot, and lowers the cost of maintaining the suite as the project evolves.
-
-Why it matters:
-
-This behavior is intentional in the current implementation and should be documented and tested so users understand the limitation.
 
 ## 7. Notes about documentation quality
 
@@ -347,5 +481,10 @@ For Core-SG, the most important coverage areas are:
 - safe reuse for smaller `k`
 - valid MST extraction
 - correct hierarchy reconstruction
+- estimator lifecycle reuse
+- HDBSCAN adapter compatibility
+- focused `score-sg` behavior
+- noise handling post-processing
+- release smoke tests against installed packages
 - explicit handling of invalid inputs
 - stable exposure of wrapped HDBSCAN-style objects

--- a/tests/integration/test_reference_equivalence.py
+++ b/tests/integration/test_reference_equivalence.py
@@ -36,6 +36,42 @@ def _reference_mst(D: np.ndarray, k: int) -> np.ndarray:
     return mst[np.argsort(mst[:, 2], kind="mergesort")]
 
 
+def _assert_clusterer_matches_native_core(
+    clusterer: CoreSGClusterer, core: CoreSG, requested_k: int
+):
+    assert np.array_equal(clusterer.labels_, core.labels_)
+    assert np.allclose(clusterer.probabilities_, core.probabilities_)
+    assert np.allclose(clusterer.cluster_persistence_, core.cluster_persistence_)
+    assert np.allclose(
+        clusterer.core_sg_._min_spanning_tree_array_,
+        core._min_spanning_tree_array_,
+    )
+    assert np.allclose(
+        clusterer.core_sg_._single_linkage_tree_array_,
+        core._single_linkage_tree_array_,
+    )
+    assert np.array_equal(
+        clusterer.core_sg_._condensed_tree_array_,
+        core._condensed_tree_array_,
+    )
+    assert clusterer.k_ == requested_k
+    assert clusterer.k_max_ == core.k_max_
+    assert clusterer.core_sg_.k_max_ == core.k_max_
+
+
+def _assert_smoke_artifacts(core: CoreSG, X: np.ndarray, *, k_max: int):
+    assert core.n_samples_ == X.shape[0]
+    assert core.k_max_ == k_max
+    assert core.labels_ is not None
+    assert core.labels_.shape == (X.shape[0],)
+    assert core.probabilities_ is not None
+    assert core.probabilities_.shape == (X.shape[0],)
+    assert core.cluster_persistence_ is not None
+    assert core.condensed_tree_.to_pandas().shape[0] >= X.shape[0]
+    assert core.single_linkage_tree_.to_pandas().shape[0] == X.shape[0] - 1
+    assert core.minimum_spanning_tree_.to_pandas().shape[0] == X.shape[0] - 1
+
+
 class TestReferenceEquivalence:
     @pytest.mark.parametrize("k", [6, 4, 2])
     def test_reference_mst_edges_are_contained_in_core_sg(self, dataset, k):
@@ -140,6 +176,68 @@ class TestIntegrationSmoke:
         assert clusterer.k_ == 2
         assert np.array_equal(labels, clusterer.labels_)
 
+    @pytest.mark.parametrize("k", [6, 4, None])
+    def test_core_sg_clusterer_outputs_match_native_core_sg(self, dataset, k):
+        k_max = 6
+        requested_k = k_max if k is None else k
+        clusterer = CoreSGClusterer(
+            k_max=k_max,
+            metric="euclidean",
+            p=2,
+            verbose=0,
+            no_noise=False,
+            match_reference_implementation=True,
+        )
+        core = CoreSG(
+            metric="euclidean",
+            p=2,
+            verbose=0,
+            no_noise=False,
+            match_reference_implementation=True,
+        )
+
+        clusterer.fit(dataset, k=k)
+        core.fit(dataset, k_max=k_max)
+        core.extract_hierarchy_from_core_sg(requested_k)
+
+        _assert_clusterer_matches_native_core(clusterer, core, requested_k)
+
+    def test_repeated_core_sg_clusterer_fit_matches_native_for_each_k(self, dataset):
+        clusterer = CoreSGClusterer(
+            k_max=6,
+            metric="euclidean",
+            p=2,
+            verbose=0,
+            no_noise=False,
+            match_reference_implementation=True,
+        )
+
+        clusterer.fit(dataset, k=6)
+        core_sg = clusterer.core_sg_
+        labels_k_max = clusterer.labels_.copy()
+        clusterer.fit(dataset, k=4)
+        labels_k4 = clusterer.labels_.copy()
+        labels_from_fit_predict = clusterer.fit_predict(dataset, k=2)
+
+        assert clusterer.core_sg_ is core_sg
+        assert np.array_equal(labels_from_fit_predict, clusterer.labels_)
+
+        for requested_k, observed_labels in [
+            (6, labels_k_max),
+            (4, labels_k4),
+            (2, labels_from_fit_predict),
+        ]:
+            core = CoreSG(
+                metric="euclidean",
+                p=2,
+                verbose=0,
+                no_noise=False,
+                match_reference_implementation=True,
+            )
+            core.fit(dataset, k_max=6)
+            core.extract_hierarchy_from_core_sg(requested_k)
+            assert np.array_equal(observed_labels, core.labels_)
+
     def test_full_fit_extract_hierarchy_and_wrapped_accessors_with_real_hdbscan(
         self, dataset
     ):
@@ -155,6 +253,41 @@ class TestIntegrationSmoke:
         assert core.condensed_tree_.to_pandas().shape[0] >= core.n_samples_
         assert core.single_linkage_tree_.to_pandas().shape[0] == core.n_samples_ - 1
         assert core.minimum_spanning_tree_.to_pandas().shape[0] == core.n_samples_ - 1
+
+    def test_core_sg_smoke_runs_two_instances_with_different_parameters(self, dataset):
+        first = CoreSG(
+            metric="euclidean",
+            p=2,
+            verbose=0,
+            no_noise=False,
+            match_reference_implementation=True,
+        )
+        second = CoreSG(
+            metric="manhattan",
+            p=2,
+            verbose=0,
+            no_noise=False,
+            cluster_selection_method="leaf",
+            allow_single_cluster=True,
+            match_reference_implementation=True,
+        )
+
+        first.fit(dataset, k_max=6)
+        first.extract_hierarchy_from_core_sg(4)
+        second.fit(dataset, k_max=5)
+        second.extract_hierarchy_from_core_sg(3)
+
+        _assert_smoke_artifacts(first, dataset, k_max=6)
+        _assert_smoke_artifacts(second, dataset, k_max=5)
+        assert first is not second
+        assert first.metric == "euclidean"
+        assert second.metric == "manhattan"
+        assert first._raw_data_ is dataset
+        assert second._raw_data_ is dataset
+        assert not np.array_equal(
+            first._min_spanning_tree_array_,
+            second._min_spanning_tree_array_,
+        )
 
     def test_score_sg_fit_extract_hierarchy_and_wrapped_accessors(self, dataset):
         connected_dataset, _ = make_blobs(
@@ -192,6 +325,53 @@ class TestIntegrationSmoke:
         assert core.condensed_tree_.to_pandas().shape[0] >= core.n_samples_
         assert core.single_linkage_tree_.to_pandas().shape[0] == core.n_samples_ - 1
         assert core.minimum_spanning_tree_.to_pandas().shape[0] == core.n_samples_ - 1
+
+    def test_score_sg_smoke_runs_two_instances_with_different_parameters(self):
+        connected_dataset, _ = make_blobs(
+            n_samples=40,
+            n_features=3,
+            centers=1,
+            cluster_std=0.75,
+            random_state=123,
+        )
+        first = CoreSG(
+            metric="euclidean",
+            p=2,
+            algorithm="score-sg",
+            random_state=42,
+            verbose=0,
+            no_noise=False,
+            match_reference_implementation=True,
+        )
+        second = CoreSG(
+            metric="euclidean",
+            p=2,
+            algorithm="score-sg",
+            random_state=7,
+            approx_knn_kwargs={"n_trees": 8},
+            verbose=0,
+            no_noise=False,
+            cluster_selection_method="leaf",
+            allow_single_cluster=True,
+            match_reference_implementation=True,
+        )
+
+        first.fit(connected_dataset, k_max=6)
+        first.extract_hierarchy_from_core_sg(4)
+        second.fit(connected_dataset, k_max=5)
+        second.extract_hierarchy_from_core_sg(3)
+
+        _assert_smoke_artifacts(first, connected_dataset, k_max=6)
+        _assert_smoke_artifacts(second, connected_dataset, k_max=5)
+        assert first is not second
+        assert first.algorithm == second.algorithm == "score-sg"
+        assert first.random_state == 42
+        assert second.random_state == 7
+        assert second.approx_knn_kwargs == {"n_trees": 8}
+        assert first.anti_hubs_.shape == (
+            int(np.floor(np.sqrt(connected_dataset.shape[0]))),
+        )
+        assert second.anti_hubs_.shape == first.anti_hubs_.shape
 
     def test_score_sg_fit_raises_explicitly_when_support_graph_is_disconnected(
         self, dataset

--- a/tests/unit/test_core_sg_fit.py
+++ b/tests/unit/test_core_sg_fit.py
@@ -91,6 +91,9 @@ class TestCoreSGFit:
         result = obj.extract_mst_from_core_sg(4)
 
         assert np.array_equal(result, obj._min_spanning_tree_k_max_array_)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (sample_X.shape[0] - 1, 3)
+        assert np.isfinite(result[:, 2]).all()
 
     def test_extract_mst_from_core_sg_to_dataframe_has_expected_schema(
         self, core_sg_module, patched_fit_dependencies, sample_X
@@ -104,6 +107,7 @@ class TestCoreSGFit:
         assert str(df["to"].dtype) == "int64"
         assert str(df["from"].dtype) == "int64"
         assert str(df["weight"].dtype) == "float64"
+        assert df.shape == (sample_X.shape[0] - 1, 3)
 
     def test_get_fitted_hdbscan_objects_raw_returns_saved_arrays(
         self, core_sg_module, patched_fit_dependencies, sample_X
@@ -125,6 +129,9 @@ class TestCoreSGFit:
         assert np.array_equal(
             fitted["minimum_spanning_tree_"], obj._min_spanning_tree_k_max_array_
         )
+        assert isinstance(fitted["condensed_tree_"], np.ndarray)
+        assert isinstance(fitted["single_linkage_tree_"], np.ndarray)
+        assert isinstance(fitted["minimum_spanning_tree_"], np.ndarray)
 
     def test_get_fitted_hdbscan_objects_wrapped_returns_hdbscan_like_wrappers(
         self, core_sg_module, patched_fit_dependencies, sample_X
@@ -139,6 +146,9 @@ class TestCoreSGFit:
         assert (
             fitted["minimum_spanning_tree_"].to_pandas().shape[0] == obj.n_samples_ - 1
         )
+        assert not isinstance(fitted["condensed_tree_"], np.ndarray)
+        assert not isinstance(fitted["single_linkage_tree_"], np.ndarray)
+        assert not isinstance(fitted["minimum_spanning_tree_"], np.ndarray)
 
     def test_minimum_spanning_tree_fit_wrapper_warns_without_raw_data(
         self, core_sg_module, patched_fit_dependencies, sample_X
@@ -232,6 +242,8 @@ class TestCoreSGFit:
             _ = obj.distance_matrix_
         assert np.array_equal(obj._tree_to_labels_data_, sample_X)
         assert np.array_equal(obj.anti_hubs_, np.array([0, 2], dtype=np.int64))
+        assert obj.anti_hubs_.shape == (int(np.floor(np.sqrt(sample_X.shape[0]))),)
+        assert np.issubdtype(obj.anti_hubs_.dtype, np.integer)
 
     def test_score_sg_fit_raises_for_disconnected_support_graph(
         self, core_sg_module, monkeypatch, sample_X

--- a/tests/unit/test_core_sg_hierarchy.py
+++ b/tests/unit/test_core_sg_hierarchy.py
@@ -159,6 +159,75 @@ class TestCoreSGHierarchy:
             obj._min_spanning_tree_array_, obj._min_spanning_tree_k_max_array_
         )
 
+    def test_extracting_smaller_k_updates_current_artifacts_without_mutating_k_max(
+        self, core_sg_module, fitted_obj, monkeypatch
+    ):
+        obj, _ = fitted_obj
+        labels_k_max = obj.labels_k_max_.copy()
+        condensed_k_max = obj._condensed_tree_k_max_array_.copy()
+        single_linkage_k_max = obj._single_linkage_tree_k_max_array_.copy()
+        mst_k_max = obj._min_spanning_tree_k_max_array_.copy()
+
+        obj.extract_hierarchy_from_core_sg(obj.k_max_)
+        first_current_mst = obj._min_spanning_tree_array_.copy()
+
+        def fake_mst_from_core_sg(
+            core_sg, metric_edges, core_k_list, n_nodes, k, verbose, progress_callback
+        ):
+            del core_sg, metric_edges, core_k_list, n_nodes, verbose
+            del progress_callback
+            return np.array(
+                [
+                    [0, 1, float(k)],
+                    [1, 2, float(k) + 0.1],
+                    [2, 3, float(k) + 0.2],
+                    [3, 4, float(k) + 0.3],
+                    [4, 5, float(k) + 0.4],
+                ],
+                dtype=np.float64,
+            )
+
+        def fake_tree_to_labels(instance, single_linkage_tree, min_spanning_tree):
+            k_marker = int(min_spanning_tree[0, 2])
+            condensed = np.column_stack(
+                [
+                    np.arange(instance.n_samples_),
+                    np.arange(instance.n_samples_),
+                    np.full(instance.n_samples_, float(k_marker)),
+                    np.full(instance.n_samples_, 2.0),
+                ]
+            ).astype(np.float64)
+            return (
+                np.full(instance.n_samples_, k_marker, dtype=np.int64),
+                np.full(instance.n_samples_, 1.0 / k_marker, dtype=np.float64),
+                np.array([float(k_marker)], dtype=np.float64),
+                condensed,
+                single_linkage_tree,
+                min_spanning_tree,
+            )
+
+        monkeypatch.setattr(core_sg_module, "mst_from_core_sg", fake_mst_from_core_sg)
+        monkeypatch.setattr(
+            core_sg_module,
+            "mst_to_single_linkage_tree",
+            lambda mst: np.asarray(mst, dtype=np.float64) + 10.0,
+        )
+        monkeypatch.setattr(core_sg_module, "tree_to_labels", fake_tree_to_labels)
+
+        obj.extract_hierarchy_from_core_sg(3)
+        second_current_mst = obj._min_spanning_tree_array_.copy()
+        obj.extract_hierarchy_from_core_sg(2)
+
+        assert np.array_equal(obj.labels_k_max_, labels_k_max)
+        assert np.array_equal(obj._condensed_tree_k_max_array_, condensed_k_max)
+        assert np.array_equal(
+            obj._single_linkage_tree_k_max_array_, single_linkage_k_max
+        )
+        assert np.array_equal(obj._min_spanning_tree_k_max_array_, mst_k_max)
+        assert np.array_equal(first_current_mst, mst_k_max)
+        assert not np.array_equal(second_current_mst, obj._min_spanning_tree_array_)
+        assert np.array_equal(obj.labels_, np.full(obj.n_samples_, 2))
+
     def test_extract_hierarchy_uses_default_c_for_noise_handler(
         self, core_sg_module, fitted_obj, monkeypatch
     ):
@@ -419,6 +488,81 @@ class TestCoreSGHierarchy:
         result = obj.extract_mst_from_core_sg(3)
 
         assert np.array_equal(result, mst_small)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (obj.n_samples_ - 1, 3)
+        assert np.isfinite(result[:, 2]).all()
+
+    def test_extract_mst_from_core_sg_smaller_k_to_dataframe(
+        self, core_sg_module, fitted_obj, monkeypatch
+    ):
+        obj, _ = fitted_obj
+        mst_small = np.array(
+            [[0, 1, 1.0], [1, 2, 1.2], [2, 3, 2.0], [3, 4, 1.1], [4, 5, 1.2]],
+            dtype=np.float64,
+        )
+        monkeypatch.setattr(
+            core_sg_module, "mst_from_core_sg", lambda *args, **kwargs: mst_small
+        )
+
+        df = obj.extract_mst_from_core_sg(3, toDF=True)
+
+        assert list(df.columns) == ["to", "from", "weight"]
+        assert str(df["to"].dtype) == "int64"
+        assert str(df["from"].dtype) == "int64"
+        assert str(df["weight"].dtype) == "float64"
+        assert df.shape == (obj.n_samples_ - 1, 3)
+
+    def test_score_sg_disconnected_mst_error_is_reworded(
+        self, core_sg_module, fitted_obj, monkeypatch
+    ):
+        obj, _ = fitted_obj
+        obj.algorithm = "score-sg"
+
+        def raise_disconnected(**kwargs):
+            del kwargs
+            raise ValueError("Disconex Graph")
+
+        monkeypatch.setattr(core_sg_module, "mst_from_core_sg", raise_disconnected)
+
+        with pytest.raises(ValueError, match="support graph is disconnected"):
+            obj.extract_mst_from_core_sg(3)
+
+    def test_extract_mst_reraises_unrelated_value_errors(
+        self, core_sg_module, fitted_obj, monkeypatch
+    ):
+        obj, _ = fitted_obj
+        obj.algorithm = "core-sg"
+
+        def raise_unrelated_error(*args, **kwargs):
+            del args, kwargs
+            raise ValueError("plain failure")
+
+        monkeypatch.setattr(core_sg_module, "mst_from_core_sg", raise_unrelated_error)
+
+        with pytest.raises(ValueError, match="plain failure"):
+            obj.extract_mst_from_core_sg(3)
+
+    def test_standalone_mst_and_reweight_helpers_validate_k(self, core_sg_module):
+        core_sg = np.array([[0.0, 1.0, -1.0]], dtype=np.float64)
+        metric_edges = np.array([[1.0, 0.0, 1.0]], dtype=np.float64)
+        core_k_list = np.ones((2, 2), dtype=np.float64)
+
+        with pytest.raises(ValueError, match="1 <= k_max <= n-1"):
+            core_sg_module.mst_from_core_sg(
+                core_sg, metric_edges, core_k_list, n_nodes=2, k=0
+            )
+        with pytest.raises(ValueError, match="reproduzir min_samples"):
+            core_sg_module.mst_from_core_sg(
+                core_sg, metric_edges, core_k_list, n_nodes=2, k=1
+            )
+        with pytest.raises(ValueError, match="1 <= k <= k_max"):
+            core_sg_module.core_sg_mutual_reachability_distance(
+                core_sg, metric_edges, core_k_list, n_nodes=2, k_max=2, k=0
+            )
+        with pytest.raises(ValueError, match="k must be >= 2"):
+            core_sg_module.core_sg_mutual_reachability_distance(
+                core_sg, metric_edges, core_k_list, n_nodes=2, k_max=2, k=1
+            )
 
     def test_extract_hierarchy_rejects_invalid_k_values(self, fitted_obj):
         obj, _ = fitted_obj

--- a/tests/unit/test_core_sg_initialization.py
+++ b/tests/unit/test_core_sg_initialization.py
@@ -110,6 +110,29 @@ class TestCoreSGInitialization:
 
         assert obj.anti_hubs_ is None
 
+    def test_property_setters_store_raw_arrays(self, core_sg_module):
+        obj = core_sg_module.CoreSG()
+
+        obj.distance_matrix_ = np.eye(2)
+        obj.condensed_tree_ = np.ones((1, 4), dtype=np.float64)
+        obj.single_linkage_tree_ = np.ones((1, 3), dtype=np.float64)
+        obj.minimum_spanning_tree_ = np.ones((1, 3), dtype=np.float64)
+
+        assert obj.distance_matrix_.shape == (2, 2)
+        assert np.array_equal(obj._condensed_tree_array_, np.ones((1, 4)))
+        assert np.array_equal(obj._single_linkage_tree_array_, np.ones((1, 3)))
+        assert np.array_equal(obj._min_spanning_tree_array_, np.ones((1, 3)))
+
+    def test_set_verbose_validates_and_updates_value(self, core_sg_module):
+        obj = core_sg_module.CoreSG()
+
+        with pytest.raises(ValueError, match="verbose"):
+            obj.set_verbose(-1)
+
+        obj.set_verbose(2)
+
+        assert obj.verbose == 2
+
     def test_get_tree_to_labels_kwargs_filters_supported_non_none_values(
         self, core_sg_module
     ):
@@ -128,6 +151,42 @@ class TestCoreSGInitialization:
             "allow_single_cluster": True,
             "cluster_selection_epsilon": 0.25,
         }
+
+    @pytest.mark.parametrize(
+        ("parameter", "value"),
+        [
+            ("cluster_selection_method", "leaf"),
+            ("allow_single_cluster", True),
+            ("match_reference_implementation", True),
+            ("cluster_selection_epsilon", 0.25),
+            ("cluster_selection_persistence", 0.3),
+            ("max_cluster_size", 7),
+            ("cluster_selection_epsilon_max", 2.5),
+        ],
+    )
+    def test_hdbscan_style_parameters_are_stored_and_considered_for_labels(
+        self, core_sg_module, parameter, value
+    ):
+        obj = core_sg_module.CoreSG(**{parameter: value})
+
+        assert obj.hdbscan_kwargs[parameter] == value
+        assert obj._get_tree_to_labels_kwargs() == {parameter: value}
+
+    def test_hdbscan_style_parameters_with_none_values_are_not_forwarded(
+        self, core_sg_module
+    ):
+        obj = core_sg_module.CoreSG(
+            cluster_selection_method=None,
+            cluster_selection_persistence=None,
+            unsupported_flag="ignored",
+        )
+
+        assert obj.hdbscan_kwargs == {
+            "cluster_selection_method": None,
+            "cluster_selection_persistence": None,
+            "unsupported_flag": "ignored",
+        }
+        assert obj._get_tree_to_labels_kwargs() == {}
 
     def test_properties_raise_before_fit_or_extract(self, core_sg_module):
         obj = core_sg_module.CoreSG()
@@ -149,6 +208,31 @@ class TestCoreSGInitialization:
 
 
 class TestBuildCoreSGInputValidation:
+    def test_build_core_sg_from_data_uses_minkowski_and_arccos_metrics(
+        self, core_sg_module
+    ):
+        X = np.array([[1.0, 0.0], [0.0, 1.0], [2.0, 0.0]], dtype=np.float64)
+
+        _, _, _, D_minkowski, _ = core_sg_module.build_core_sg_from_data(
+            X, k_max=2, metric="minkowski", p=3
+        )
+        _, _, _, D_arccos, _ = core_sg_module.build_core_sg_from_data(
+            X, k_max=2, metric="arccos"
+        )
+
+        assert D_minkowski.shape == (3, 3)
+        assert D_arccos.shape == (3, 3)
+
+    def test_build_by_algorithm_rejects_invalid_internal_algorithm(
+        self, core_sg_module
+    ):
+        obj = core_sg_module.CoreSG()
+        obj.algorithm = "invalid"
+        X = np.array([[0.0], [1.0], [2.0]], dtype=np.float64)
+
+        with pytest.raises(ValueError, match="algorithm"):
+            obj._build_by_algorithm(X, k_max=2)
+
     def test_build_core_sg_from_data_rejects_single_point_input(self, core_sg_module):
         X = np.array([[0.0, 1.0]], dtype=np.float64)
 

--- a/tests/unit/test_estimators.py
+++ b/tests/unit/test_estimators.py
@@ -154,6 +154,21 @@ class TestCoreSGClusterer:
         assert np.array_equal(labels, clusterer.labels_)
         assert clusterer.k_ == 2
 
+    def test_fit_predict_after_fit_reuses_existing_core_sg(
+        self, estimators_module, sample_X
+    ):
+        clusterer = estimators_module.CoreSGClusterer(k_max=4)
+        clusterer.fit(sample_X, k=3)
+        core_sg = clusterer.core_sg_
+
+        labels = clusterer.fit_predict(sample_X.copy(), k=2)
+
+        assert clusterer.core_sg_ is core_sg
+        assert FakeCoreSG.instances == [core_sg]
+        assert len(core_sg.fit_calls) == 1
+        assert core_sg.extract_calls == [3, 2]
+        assert np.array_equal(labels, clusterer.labels_)
+
     def test_constructor_parameters_are_forwarded_without_mutating_dict(
         self, estimators_module, sample_X
     ):
@@ -217,6 +232,36 @@ class TestCoreSGClusterer:
         assert not hasattr(cloned, "core_sg_")
         assert not hasattr(cloned, "labels_")
 
+    def test_clone_fitted_clusterer_drops_learned_attributes(
+        self, estimators_module, sample_X
+    ):
+        clusterer = estimators_module.CoreSGClusterer(k_max=4)
+        clusterer.fit(sample_X, k=3)
+
+        cloned = clone(clusterer)
+
+        assert cloned.get_params() == clusterer.get_params()
+        for attribute in [
+            "core_sg_",
+            "k_max_",
+            "k_",
+            "labels_",
+            "probabilities_",
+            "cluster_persistence_",
+            "condensed_tree_",
+            "single_linkage_tree_",
+            "minimum_spanning_tree_",
+        ]:
+            assert not hasattr(cloned, attribute)
+
+    def test_get_fitted_core_sg_returns_native_object(
+        self, estimators_module, sample_X
+    ):
+        clusterer = estimators_module.CoreSGClusterer(k_max=4)
+        clusterer.fit(sample_X, k=3)
+
+        assert clusterer.get_fitted_core_sg() is clusterer.core_sg_
+
     def test_get_fitted_core_sg_raises_before_fit(self, estimators_module):
         clusterer = estimators_module.CoreSGClusterer(k_max=4)
 
@@ -226,7 +271,7 @@ class TestCoreSGClusterer:
         with pytest.raises(AttributeError):
             _ = clusterer.labels_
 
-    @pytest.mark.parametrize("k_max", [1, 6, 1.5, True])
+    @pytest.mark.parametrize("k_max", [1, 0, -1, 6, 1.5, True])
     def test_invalid_k_max_values_raise_clear_value_error(
         self, estimators_module, sample_X, k_max
     ):
@@ -235,7 +280,7 @@ class TestCoreSGClusterer:
         with pytest.raises(ValueError, match="k_max"):
             clusterer.fit(sample_X)
 
-    @pytest.mark.parametrize("k", [1, 5, 2.5, False])
+    @pytest.mark.parametrize("k", [1, 0, -1, 5, 2.5, True, False])
     def test_invalid_k_values_raise_clear_value_error(
         self, estimators_module, sample_X, k
     ):
@@ -244,6 +289,47 @@ class TestCoreSGClusterer:
         with pytest.raises(ValueError, match="k"):
             clusterer.fit(sample_X, k=k)
 
+    @pytest.mark.parametrize(
+        "bad_X",
+        [
+            np.array([0.0, 1.0, 2.0], dtype=np.float64),
+            np.empty((0, 2), dtype=np.float64),
+            np.array([[0.0, 1.0]], dtype=np.float64),
+            np.array([[0.0, 1.0], [np.nan, 2.0], [3.0, 4.0]], dtype=np.float64),
+            np.array([[0.0, 1.0], [np.inf, 2.0], [3.0, 4.0]], dtype=np.float64),
+        ],
+    )
+    def test_first_fit_rejects_invalid_dense_X(self, estimators_module, bad_X):
+        clusterer = estimators_module.CoreSGClusterer(k_max=2)
+
+        with pytest.raises(ValueError):
+            clusterer.fit(bad_X)
+
+    def test_first_fit_rejects_sparse_X(self, estimators_module, sample_X):
+        sparse = pytest.importorskip("scipy.sparse")
+        clusterer = estimators_module.CoreSGClusterer(k_max=4)
+
+        with pytest.raises(TypeError):
+            clusterer.fit(sparse.csr_matrix(sample_X))
+
+    def test_later_fit_skips_X_validation_but_still_validates_k(
+        self, estimators_module, sample_X
+    ):
+        clusterer = estimators_module.CoreSGClusterer(k_max=4)
+        clusterer.fit(sample_X, k=3)
+        core_sg = clusterer.core_sg_
+        invalid_X = np.array([np.nan], dtype=np.float64)
+
+        clusterer.fit(invalid_X, k=None)
+
+        assert clusterer.core_sg_ is core_sg
+        assert len(core_sg.fit_calls) == 1
+        assert core_sg.extract_calls == [3, 4]
+        assert clusterer.k_ == clusterer.k_max_ == 4
+
+        with pytest.raises(ValueError, match="k"):
+            clusterer.fit(invalid_X, k=5)
+
     def test_precomputed_metric_is_rejected_in_wrapper(
         self, estimators_module, sample_X
     ):
@@ -251,3 +337,14 @@ class TestCoreSGClusterer:
 
         with pytest.raises(ValueError, match="precomputed"):
             clusterer.fit(sample_X)
+
+    def test_validate_x_falls_back_when_validate_data_is_unavailable(
+        self, estimators_module, monkeypatch
+    ):
+        monkeypatch.setattr(estimators_module, "validate_data", None)
+        clusterer = estimators_module.CoreSGClusterer(k_max=2)
+
+        X_checked = clusterer._validate_X([[0.0, 1.0], [1.0, 0.0]])
+
+        assert X_checked.dtype == np.float64
+        assert clusterer.n_features_in_ == 2

--- a/tests/unit/test_graph_helpers.py
+++ b/tests/unit/test_graph_helpers.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import builtins
 import inspect
+import importlib
+import sys
+import warnings
 
 import numpy as np
 import pytest
@@ -16,6 +20,26 @@ from core_sg.reweight import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+def _import_module_with_blocked_import(
+    module_name: str,
+    blocked_names: set[str],
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in blocked_names or name.rsplit(".", 1)[-1] in blocked_names:
+            raise ImportError(f"blocked optional import: {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for name in list(sys.modules):
+        if name == "core_sg" or name.startswith("core_sg."):
+            del sys.modules[name]
+    return importlib.import_module(module_name)
 
 
 class TestGraphHelpers:
@@ -214,3 +238,121 @@ class TestGraphHelpers:
 
         with pytest.raises(ValueError, match="NxN"):
             core_sg_module.knn_from_precomputed(D, k=1)
+
+    def test_knn_from_precomputed_validates_k_with_and_without_self(
+        self, core_sg_module
+    ):
+        D = np.array([[0.0, 2.0], [2.0, 0.0]], dtype=np.float64)
+
+        with pytest.raises(ValueError, match="excluindo self"):
+            core_sg_module.knn_from_precomputed(D, k=0, include_self=False)
+        with pytest.raises(ValueError, match="incluindo self"):
+            core_sg_module.knn_from_precomputed(D, k=3, include_self=True)
+
+        idx, dist = core_sg_module.knn_from_precomputed(D, k=2, include_self=True)
+
+        assert np.array_equal(idx[:, 0], np.array([0, 1], dtype=np.int64))
+        assert np.array_equal(dist[:, 0], np.array([0.0, 0.0]))
+
+    def test_build_knng_vectors_validates_input_shapes(self, core_sg_module):
+        idxs = np.array([[1, 0]], dtype=np.int64)
+        dists = np.array([[1.0, 1.0]], dtype=np.float64)
+
+        with pytest.raises(ValueError, match="idxs_arr.shape"):
+            core_sg_module.build_knng_vectors(idxs, dists, knng_size=2, k_max=1)
+
+        with pytest.raises(ValueError, match="distance_arr.shape"):
+            core_sg_module.build_knng_vectors(
+                np.array([[1], [0]], dtype=np.int64),
+                dists,
+                knng_size=2,
+                k_max=1,
+            )
+
+    def test_add_mst_edges_validates_shapes_and_returns_original_when_all_exist(
+        self, core_sg_module
+    ):
+        with pytest.raises(ValueError, match="metric_edges"):
+            core_sg_module.add_mst_edges_to_metric_edges(
+                np.array([1.0, 2.0]), np.array([[0.0, 1.0, 1.0]])
+            )
+
+        with pytest.raises(ValueError, match="mst"):
+            core_sg_module.add_mst_edges_to_metric_edges(
+                np.array([[1.0, 0.0, 1.0]]), np.array([0.0, 1.0, 1.0])
+            )
+
+        metric_edges = np.array([[1.0, 0.0, 1.0]], dtype=np.float64)
+        mst = np.array([[0.0, 1.0, 1.0]], dtype=np.float64)
+
+        result = core_sg_module.add_mst_edges_to_metric_edges(metric_edges, mst)
+
+        assert np.array_equal(result, metric_edges)
+
+    def test_kruskal_python_fallback_and_union_rank_branches(
+        self, fake_hdbscan_modules, monkeypatch
+    ):
+        del fake_hdbscan_modules
+        module = _import_module_with_blocked_import(
+            "core_sg.mst_kruskal",
+            {"_mst_kruskal"},
+            monkeypatch=monkeypatch,
+        )
+        assert module._kruskal_mst_impl is None
+
+        edges = np.array([[0.0, 1.0, 1.0], [1.0, 2.0, 2.0]], dtype=np.float64)
+        with pytest.warns(RuntimeWarning, match="Cython backend"):
+            module.kruskal_mst(edges, n_nodes=3)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            module.kruskal_mst(edges, n_nodes=3)
+
+        uf = module.UnionFind(3)
+        assert uf.union(0, 1) is True
+        assert uf.union(2, 0) is True
+        assert uf.find(2) == uf.find(0)
+
+        with pytest.raises(ValueError, match="shape"):
+            module.kruskal_mst(np.array([1.0, 2.0, 3.0]), n_nodes=3)
+        with pytest.raises(ValueError, match="n_nodes"):
+            module.kruskal_mst(edges, n_nodes=1)
+        with pytest.raises(ValueError, match="Disconex Graph"):
+            module._kruskal_mst_python(np.array([[0.0, 1.0, 1.0]]), n_nodes=3)
+
+    def test_reweight_python_fallback_validation_and_cache_miss(
+        self, fake_hdbscan_modules, monkeypatch
+    ):
+        del fake_hdbscan_modules
+        module = _import_module_with_blocked_import(
+            "core_sg.reweight",
+            {"_reweight"},
+            monkeypatch=monkeypatch,
+        )
+        assert module._reweight_core_sg_from_lookup is None
+
+        with pytest.raises(ValueError, match="mst"):
+            module.sort_core_sg(np.array([1.0, 2.0, 3.0]))
+
+        w_sorted = np.array([1.0], dtype=np.float64)
+        with pytest.raises(KeyError, match="missing"):
+            module._reweight_core_sg_python(
+                np.array([[0.0, 1.0, -1.0]]),
+                np.ones(3, dtype=np.float64),
+                np.array([4], dtype=np.int64),
+                w_sorted,
+                n_nodes=3,
+            )
+
+        core_sg = np.array([[0.0, 1.0, -1.0]], dtype=np.float64)
+        metric_edges = np.array([[1.0, 0.0, 1.0]], dtype=np.float64)
+        core_k = np.array([0.5, 0.7], dtype=np.float64)
+        with pytest.warns(RuntimeWarning, match="Cython backend"):
+            module.reweight_core_sg_mutual_reachability(
+                core_sg, core_k, metric_edges, n_nodes=2
+            )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            module.reweight_core_sg_mutual_reachability(
+                core_sg, core_k, metric_edges, n_nodes=2
+            )

--- a/tests/unit/test_hdbscan_adapter.py
+++ b/tests/unit/test_hdbscan_adapter.py
@@ -15,6 +15,17 @@ def hdbscan_adapter_module(fake_hdbscan_modules):
 
 
 class TestHDBSCANAdapter:
+    @staticmethod
+    def _minimal_tree_to_labels_result(data, single_linkage_tree):
+        n = np.asarray(data).shape[0]
+        return (
+            np.zeros(n, dtype=np.int64),
+            np.ones(n, dtype=np.float64),
+            np.array([1.0], dtype=np.float64),
+            np.zeros((n, 4), dtype=np.float64),
+            np.asarray(single_linkage_tree),
+        )
+
     def test_reference_mst_original_distance_uses_expected_hdbscan_parameters(
         self, hdbscan_adapter_module
     ):
@@ -79,6 +90,190 @@ class TestHDBSCANAdapter:
         assert condensed.shape[0] == data.shape[0]
         assert np.array_equal(slt, single_linkage_tree)
         assert np.array_equal(mst, min_spanning_tree)
+
+    @pytest.mark.parametrize(
+        ("signature_name", "factory", "expected_kwargs"),
+        [
+            (
+                "current_full",
+                lambda seen, result: (
+                    lambda data, single_linkage_tree, cluster_selection_method="eom", allow_single_cluster=False, match_reference_implementation=False, cluster_selection_epsilon=0.0, cluster_selection_persistence=0.0, max_cluster_size=0, cluster_selection_epsilon_max=float("inf"): (
+                        seen.__setitem__(
+                            "kwargs",
+                            {
+                                "cluster_selection_method": cluster_selection_method,
+                                "allow_single_cluster": allow_single_cluster,
+                                "match_reference_implementation": (
+                                    match_reference_implementation
+                                ),
+                                "cluster_selection_epsilon": cluster_selection_epsilon,
+                                "cluster_selection_persistence": (
+                                    cluster_selection_persistence
+                                ),
+                                "max_cluster_size": max_cluster_size,
+                                "cluster_selection_epsilon_max": (
+                                    cluster_selection_epsilon_max
+                                ),
+                            },
+                        )
+                        or result(data, single_linkage_tree)
+                    )
+                ),
+                {
+                    "cluster_selection_method": "leaf",
+                    "allow_single_cluster": True,
+                    "match_reference_implementation": True,
+                    "cluster_selection_epsilon": 0.25,
+                    "cluster_selection_persistence": 0.4,
+                    "max_cluster_size": 7,
+                    "cluster_selection_epsilon_max": 3.5,
+                },
+            ),
+            (
+                "without_persistence",
+                lambda seen, result: (
+                    lambda data, single_linkage_tree, cluster_selection_method="eom", allow_single_cluster=False, match_reference_implementation=False, cluster_selection_epsilon=0.0, max_cluster_size=0, cluster_selection_epsilon_max=float("inf"): (
+                        seen.__setitem__(
+                            "kwargs",
+                            {
+                                "cluster_selection_method": cluster_selection_method,
+                                "allow_single_cluster": allow_single_cluster,
+                                "match_reference_implementation": (
+                                    match_reference_implementation
+                                ),
+                                "cluster_selection_epsilon": cluster_selection_epsilon,
+                                "max_cluster_size": max_cluster_size,
+                                "cluster_selection_epsilon_max": (
+                                    cluster_selection_epsilon_max
+                                ),
+                            },
+                        )
+                        or result(data, single_linkage_tree)
+                    )
+                ),
+                {
+                    "cluster_selection_method": "leaf",
+                    "allow_single_cluster": True,
+                    "match_reference_implementation": True,
+                    "cluster_selection_epsilon": 0.25,
+                    "max_cluster_size": 7,
+                    "cluster_selection_epsilon_max": 3.5,
+                },
+            ),
+            (
+                "without_epsilon_max",
+                lambda seen, result: (
+                    lambda data, single_linkage_tree, cluster_selection_method="eom", allow_single_cluster=False, match_reference_implementation=False, cluster_selection_epsilon=0.0, cluster_selection_persistence=0.0, max_cluster_size=0: (
+                        seen.__setitem__(
+                            "kwargs",
+                            {
+                                "cluster_selection_method": cluster_selection_method,
+                                "allow_single_cluster": allow_single_cluster,
+                                "match_reference_implementation": (
+                                    match_reference_implementation
+                                ),
+                                "cluster_selection_epsilon": cluster_selection_epsilon,
+                                "cluster_selection_persistence": (
+                                    cluster_selection_persistence
+                                ),
+                                "max_cluster_size": max_cluster_size,
+                            },
+                        )
+                        or result(data, single_linkage_tree)
+                    )
+                ),
+                {
+                    "cluster_selection_method": "leaf",
+                    "allow_single_cluster": True,
+                    "match_reference_implementation": True,
+                    "cluster_selection_epsilon": 0.25,
+                    "cluster_selection_persistence": 0.4,
+                    "max_cluster_size": 7,
+                },
+            ),
+            (
+                "no_optional_kwargs",
+                lambda seen, result: (
+                    lambda data, single_linkage_tree: (
+                        seen.__setitem__("kwargs", {})
+                        or result(data, single_linkage_tree)
+                    )
+                ),
+                {},
+            ),
+        ],
+    )
+    def test_tree_to_labels_filters_against_multiple_private_signatures(
+        self,
+        hdbscan_adapter_module,
+        monkeypatch,
+        signature_name,
+        factory,
+        expected_kwargs,
+    ):
+        del signature_name
+        data = np.zeros((4, 2), dtype=np.float64)
+        single_linkage_tree = np.array(
+            [[0, 1, 1.0], [1, 2, 2.0], [2, 3, 3.0]], dtype=np.float64
+        )
+        tree_kwargs = {
+            "cluster_selection_method": "leaf",
+            "allow_single_cluster": True,
+            "match_reference_implementation": True,
+            "cluster_selection_epsilon": 0.25,
+            "cluster_selection_persistence": 0.4,
+            "max_cluster_size": 7,
+            "cluster_selection_epsilon_max": 3.5,
+            "unsupported_flag": "drop-me",
+        }
+        seen = {}
+        monkeypatch.setattr(
+            hdbscan_adapter_module,
+            "_tree_to_labels",
+            factory(seen, self._minimal_tree_to_labels_result),
+        )
+
+        result = hdbscan_adapter_module.tree_to_labels(
+            data,
+            single_linkage_tree,
+            tree_kwargs=tree_kwargs,
+            min_spanning_tree=single_linkage_tree,
+        )
+
+        assert seen["kwargs"] == expected_kwargs
+        assert np.array_equal(result[-1], single_linkage_tree)
+
+    def test_tree_to_labels_preserves_unknown_kwargs_when_signature_accepts_kwargs(
+        self, hdbscan_adapter_module, monkeypatch
+    ):
+        seen = {}
+
+        def fake_tree_to_labels(data, single_linkage_tree, **kwargs):
+            seen["kwargs"] = kwargs
+            return self._minimal_tree_to_labels_result(data, single_linkage_tree)
+
+        monkeypatch.setattr(
+            hdbscan_adapter_module, "_tree_to_labels", fake_tree_to_labels
+        )
+        data = np.zeros((4, 2), dtype=np.float64)
+        single_linkage_tree = np.array(
+            [[0, 1, 1.0], [1, 2, 2.0], [2, 3, 3.0]], dtype=np.float64
+        )
+        tree_kwargs = {
+            "cluster_selection_method": "leaf",
+            "allow_single_cluster": True,
+            "unsupported_flag": "keep-me",
+        }
+
+        result = hdbscan_adapter_module.tree_to_labels(
+            data,
+            single_linkage_tree,
+            tree_kwargs=tree_kwargs,
+            min_spanning_tree=single_linkage_tree,
+        )
+
+        assert seen["kwargs"] == tree_kwargs
+        assert np.array_equal(result[-1], single_linkage_tree)
 
     def test_tree_to_labels_filters_kwargs_unsupported_by_installed_hdbscan(
         self, hdbscan_adapter_module, monkeypatch

--- a/tests/unit/test_noise_handler.py
+++ b/tests/unit/test_noise_handler.py
@@ -155,3 +155,20 @@ class TestMSTLabelPropagationStrategy:
 
         with pytest.raises(ValueError, match="shape \\(n_edges, 3\\)"):
             handler.reassign(labels=labels, min_spanning_tree=mst, n_samples=3)
+
+    def test_reassign_validates_mst_edge_count(self, noise_handler_module):
+        labels = np.array([0, -1, 1], dtype=np.int64)
+        mst = np.array([[0.0, 1.0, 1.0]], dtype=np.float64)
+        handler = noise_handler_module.MSTLabelPropagationStrategy(c=2)
+
+        with pytest.raises(ValueError, match="n_samples - 1"):
+            handler.reassign(labels=labels, min_spanning_tree=mst, n_samples=3)
+
+    def test_reassign_skips_already_labeled_neighbors(self, noise_handler_module):
+        labels = np.array([0, 1, -1], dtype=np.int64)
+        mst = np.array([[0.0, 1.0, 1.0], [1.0, 2.0, 2.0]], dtype=np.float64)
+        handler = noise_handler_module.MSTLabelPropagationStrategy(c=2)
+
+        result = handler.reassign(labels=labels, min_spanning_tree=mst, n_samples=3)
+
+        assert np.array_equal(result, np.array([0, 1, 1], dtype=np.int64))

--- a/tests/unit/test_score_sg.py
+++ b/tests/unit/test_score_sg.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import builtins
 import importlib
+import sys
 
 import numpy as np
 import pytest
@@ -10,12 +12,31 @@ from tests.helpers import make_sample_X, normalize_undirected_edges
 pytestmark = pytest.mark.unit
 
 
+def _import_score_sg_with_blocked_pynndescent(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pynndescent":
+            raise ImportError("blocked optional import: pynndescent")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for name in list(sys.modules):
+        if name == "core_sg" or name.startswith("core_sg."):
+            del sys.modules[name]
+    return importlib.import_module("core_sg.score_sg")
+
+
 @pytest.fixture()
 def score_sg_module(fake_hdbscan_modules):
     return importlib.import_module("core_sg.score_sg")
 
 
 class TestScoreSGUtilities:
+    def test_metric_resolution_and_kwargs_helpers(self, score_sg_module):
+        assert score_sg_module._resolve_metric("arccos") == "cosine"
+        assert score_sg_module._metric_kwargs("minkowski", 3) == {"p": 3}
+
     def test_build_approximate_core_k_list_uses_approximate_neighbor_distances(
         self, score_sg_module
     ):
@@ -30,6 +51,14 @@ class TestScoreSGUtilities:
             result,
             np.array([[0.0, 0.2, 0.5], [0.0, 0.3, 0.7]], dtype=np.float64),
         )
+
+    def test_build_approximate_core_k_list_handles_k_max_one(self, score_sg_module):
+        result = score_sg_module.build_approximate_core_k_list(
+            np.array([[2.0], [3.0]], dtype=np.float64),
+            1,
+        )
+
+        assert np.array_equal(result, np.zeros((2, 1), dtype=np.float64))
 
     def test_compute_in_degrees_counts_directed_occurrences(self, score_sg_module):
         neighbor_indices = np.array(
@@ -93,6 +122,53 @@ class TestScoreSGUtilities:
         )
 
         assert np.array_equal(selected_a, selected_b)
+
+    def test_select_score_sg_anti_hubs_returns_all_points_when_selection_is_full(
+        self, score_sg_module
+    ):
+        selected = score_sg_module.select_score_sg_anti_hubs(
+            np.empty((1, 0), dtype=np.int64),
+            np.array([0], dtype=np.int64),
+            random_state=0,
+        )
+
+        assert np.array_equal(selected, np.array([0], dtype=np.int64))
+
+    def test_normalize_neighbor_graph_rejects_rows_without_enough_neighbors(
+        self, score_sg_module
+    ):
+        with pytest.raises(ValueError, match="enough neighbors"):
+            score_sg_module._normalize_neighbor_graph(
+                np.array([[0, 1]], dtype=np.int64),
+                np.array([[0.0, 1.0]], dtype=np.float64),
+                k_max=2,
+            )
+
+    def test_build_selected_clique_returns_empty_arrays_for_single_selection(
+        self, score_sg_module
+    ):
+        metric_edges, support_edges = score_sg_module.build_selected_clique(
+            np.array([[0.0, 0.0]], dtype=np.float64),
+            np.array([0], dtype=np.int64),
+            metric="euclidean",
+            p=2,
+        )
+
+        assert metric_edges.shape == (0, 3)
+        assert support_edges.shape == (0, 3)
+
+    def test_is_graph_connected_handles_trivial_empty_and_self_loop_graphs(
+        self, score_sg_module
+    ):
+        assert score_sg_module.is_graph_connected(np.empty((0, 3)), 1) is True
+        assert score_sg_module.is_graph_connected(np.empty((0, 3)), 2) is False
+        assert (
+            score_sg_module.is_graph_connected(
+                np.array([[0.0, 0.0, -1.0], [0.0, 1.0, -1.0]]),
+                2,
+            )
+            is True
+        )
 
 
 class TestScoreSGBuild:
@@ -175,6 +251,106 @@ class TestScoreSGBuild:
                 approx_knn_kwargs={"compressed": True},
             )
 
+    def test_build_approximate_knn_graph_does_not_mutate_kwargs(
+        self, score_sg_module, monkeypatch
+    ):
+        class FakeNNDescent:
+            def __init__(self, X, metric="euclidean", **kwargs):
+                del X, metric, kwargs
+                self._neighbor_graph = (
+                    np.array(
+                        [
+                            [0, 1, 2],
+                            [1, 0, 2],
+                            [2, 1, 0],
+                        ],
+                        dtype=np.int64,
+                    ),
+                    np.array(
+                        [
+                            [0.0, 1.0, 2.0],
+                            [0.0, 1.0, 1.5],
+                            [0.0, 1.5, 2.0],
+                        ],
+                        dtype=np.float64,
+                    ),
+                )
+
+            @property
+            def neighbor_graph(self):
+                return self._neighbor_graph
+
+        monkeypatch.setattr(
+            score_sg_module, "_get_pynndescent_class", lambda: FakeNNDescent
+        )
+        approx_knn_kwargs = {"n_neighbors": 1, "random_state": 99}
+
+        score_sg_module.build_approximate_knn_graph(
+            make_sample_X()[:3],
+            2,
+            metric="euclidean",
+            p=2,
+            random_state=17,
+            approx_knn_kwargs=approx_knn_kwargs,
+        )
+
+        assert approx_knn_kwargs == {"n_neighbors": 1, "random_state": 99}
+
+    def test_build_approximate_knn_graph_passes_minkowski_metric_kwargs(
+        self, score_sg_module, monkeypatch
+    ):
+        seen = {}
+
+        class FakeNNDescent:
+            def __init__(self, X, metric="euclidean", **kwargs):
+                del X
+                seen["metric"] = metric
+                seen["kwargs"] = kwargs
+                self.neighbor_graph = (
+                    np.array([[0, 1], [1, 0]], dtype=np.int64),
+                    np.array([[0.0, 2.0], [0.0, 2.0]], dtype=np.float64),
+                )
+
+        monkeypatch.setattr(
+            score_sg_module, "_get_pynndescent_class", lambda: FakeNNDescent
+        )
+
+        idx, dist = score_sg_module.build_approximate_knn_graph(
+            np.array([[0.0], [2.0]], dtype=np.float64),
+            1,
+            metric="minkowski",
+            p=5,
+            random_state=13,
+            approx_knn_kwargs=None,
+        )
+
+        assert seen["metric"] == "minkowski"
+        assert seen["kwargs"]["metric_kwds"] == {"p": 5}
+        assert np.array_equal(idx, np.array([[1], [0]], dtype=np.int64))
+        assert np.array_equal(dist, np.array([[2.0], [2.0]], dtype=np.float64))
+
+    def test_build_approximate_knn_graph_rejects_missing_neighbor_graph(
+        self, score_sg_module, monkeypatch
+    ):
+        class NoGraphNNDescent:
+            def __init__(self, X, metric="euclidean", **kwargs):
+                del X, metric, kwargs
+                self.neighbor_graph = None
+
+        monkeypatch.setattr(
+            score_sg_module, "_get_pynndescent_class", lambda: NoGraphNNDescent
+        )
+
+        with pytest.raises(ValueError, match="neighbor_graph"):
+            score_sg_module.build_approximate_knn_graph(
+                np.array([[0.0], [1.0]], dtype=np.float64),
+                1,
+                metric="euclidean",
+                p=2,
+                random_state=0,
+                approx_knn_kwargs=None,
+            )
+
     def test_build_score_sg_from_data_returns_shared_payload_without_dense_D(
         self, score_sg_module, monkeypatch
     ):
@@ -218,6 +394,34 @@ class TestScoreSGBuild:
         assert (0, 3, round(np.linalg.norm(X[0] - X[3]), 4)) in undirected_metric_edges
         assert (0, 3, -1.0) in undirected_core_sg
 
+    def test_build_score_sg_from_data_uses_knn_support_when_no_clique_is_built(
+        self, score_sg_module, monkeypatch
+    ):
+        X = np.array([[0.0, 0.0]], dtype=np.float64)
+        monkeypatch.setattr(
+            score_sg_module,
+            "build_approximate_knn_graph",
+            lambda *args, **kwargs: (
+                np.array([[0]], dtype=np.int64),
+                np.array([[0.0]], dtype=np.float64),
+            ),
+        )
+        monkeypatch.setattr(
+            score_sg_module,
+            "select_score_sg_anti_hubs",
+            lambda *args, **kwargs: np.array([0], dtype=np.int64),
+        )
+
+        core_sg, metric_edges, core_k_list, tree_data, selected = (
+            score_sg_module.build_score_sg_from_data(X, 1)
+        )
+
+        assert core_sg.shape == (1, 3)
+        assert metric_edges.shape == (1, 3)
+        assert core_k_list.shape == (1, 1)
+        assert np.array_equal(tree_data, X)
+        assert np.array_equal(selected, np.array([0], dtype=np.int64))
+
     def test_is_graph_connected_detects_connected_and_disconnected_graphs(
         self, score_sg_module
     ):
@@ -249,3 +453,13 @@ class TestScoreSGBuild:
                 approx_knn_kwargs=None,
             )
         assert "missing pynndescent" in str(score_sg_module._PYNNDESCENT_IMPORT_ERROR)
+
+    def test_score_sg_import_handles_missing_pynndescent(
+        self, fake_hdbscan_modules, monkeypatch
+    ):
+        del fake_hdbscan_modules
+        module = _import_score_sg_with_blocked_pynndescent(monkeypatch)
+
+        assert module.NNDescent is None
+        with pytest.raises(ImportError, match="pynndescent"):
+            module._get_pynndescent_class()


### PR DESCRIPTION
## Summary

Increases project test coverage to at least 99% by adding focused unit tests to the existing domain-specific test files.

Closes #70

## Changes

- Adds validation coverage for `knn`, `edges`, `mst_kruskal`, and `reweight`.
- Covers fallback paths when optional Cython extensions or optional dependencies are unavailable.
- Adds tests for `CoreSG` validation paths, properties, and setters.
- Expands coverage for `score-sg` utilities and build flows.
- Adds extra scenarios for `CoreSGClusterer`.
- Covers additional validation and branch paths in `noise_handler`.
- Keeps tests organized in the existing specific test files instead of adding a coverage-only test file.

## Validation

Run with `.venv310`:

```bash
.venv310/bin/ruff check tests/unit/test_graph_helpers.py tests/unit/test_core_sg_initialization.py tests/unit/test_core_sg_hierarchy.py tests/unit/test_estimators.py tests/unit/test_score_sg.py tests/unit/test_noise_handler.py
.venv310/bin/pytest --cov=core_sg --cov-report=term-missing
```

Result:

```text
183 passed, 1 warning
TOTAL: 99%
```

## Note

The global `python` environment failed to import NumPy/OpenBLAS, so validation was run with `.venv310`, which works for the test suite.
